### PR TITLE
Added pubkey authentication

### DIFF
--- a/src/main/java/org/syncany/plugins/sftp/SftpTransferSettings.java
+++ b/src/main/java/org/syncany/plugins/sftp/SftpTransferSettings.java
@@ -1,6 +1,6 @@
 /*
  * Syncany, www.syncany.org
- * Copyright (C) 2011-2014 Philipp C. Heckel <philipp.heckel@gmail.com> 
+ * Copyright (C) 2011-2014 Philipp C. Heckel <philipp.heckel@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
  */
 package org.syncany.plugins.sftp;
 
+import java.io.File;
 import java.util.Map;
 
 import org.syncany.plugins.PluginOptionSpec;
@@ -27,57 +28,69 @@ import org.syncany.plugins.transfer.TransferSettings;
 
 /**
  * The SFTP connection represents the settings required to connect to an
- * SFTP-based storage backend. It can be used to initialize/create an 
- * {@link SftpTransferManager} and is part of the {@link SftpPlugin}.  
+ * SFTP-based storage backend. It can be used to initialize/create an
+ * {@link SftpTransferManager} and is part of the {@link SftpPlugin}.
  *
  * @author Vincent Wiencek <vwiencek@gmail.com>
+ * @author Christian Roth <christian.roth@port17.de>
  */
 public class SftpTransferSettings extends TransferSettings {
-    private String hostname;
-    private String username;
-    private String password;
-    private String path;
-    private int port;
-  
-    public String getHostname() {
-        return hostname;
-    }
+	private static final String NO_KEY = "none";
 
-    public void setHostname(String hostname) {
-        this.hostname = hostname;
-    }
+	private String hostname;
+	private File privateKey;
+	private String username;
+	private String password;
+	private String path;
+	private int port;
 
-    public String getPassword() {
-        return password;
-    }
+	public String getHostname() {
+		return hostname;
+	}
 
-    public void setPassword(String password) {
-        this.password = password;
-    }
+	public void setHostname(String hostname) {
+		this.hostname = hostname;
+	}
 
-    public String getPath() {
-        return path;
-    }
+	public String getPassword() {
+		return password;
+	}
 
-    public void setPath(String path) {        
-        this.path = path;
-    }
+	public void setPassword(String password) {
+		this.password = password;
+	}
 
-    public int getPort() {
-        return port;
-    }
+	public String getPath() {
+		return path;
+	}
 
-    public void setPort(int port) {
-        this.port = port;
-    }
+	public void setPath(String path) {
+		this.path = path;
+	}
 
-    public String getUsername() {
-        return username;
-    }
+	public int getPort() {
+		return port;
+	}
 
-    public void setUsername(String username) {
-        this.username = username;
-    }
+	public void setPort(int port) {
+		this.port = port;
+	}
+
+	public String getUsername() {
+		return username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public File getPrivateKey() {
+		return privateKey;
+	}
+
+	public void setPrivateKey(File privateKey) {
+		this.privateKey = privateKey;
+	}
 
 	@Override
 	public void init(Map<String, String> optionValues) throws StorageException {
@@ -87,22 +100,28 @@ public class SftpTransferSettings extends TransferSettings {
 		this.password = optionValues.get("password");
 		this.path = optionValues.get("path");
 		this.port = Integer.parseInt(optionValues.get("port"));
+
+		if (optionValues.get("privatekey") != null && !NO_KEY.equalsIgnoreCase(optionValues.get("privatekey"))) {
+			this.privateKey = new File(optionValues.get("privatekey"));
+			if (!this.privateKey.isFile() || !this.privateKey.canRead()) throw new StorageException("Not a valid privatekey");
+		}
 	}
 
-	@Override 
+	@Override
 	public PluginOptionSpecs getOptionSpecs() {
 		return new PluginOptionSpecs(
 			new PluginOptionSpec("hostname", "Hostname", ValueType.STRING, true, false, null),
+			new PluginOptionSpec("privatekey", "Privatekey Path", ValueType.STRING, false, false, NO_KEY),
 			new PluginOptionSpec("username", "Username", ValueType.STRING, true, false, null),
 			new PluginOptionSpec("password", "Password", ValueType.STRING, true, true, null),
 			new PluginOptionSpec("path", "Path", ValueType.STRING, true, false, null),
 			new PluginOptionSpec("port", "Port", ValueType.INT, false, false, "22")
-		);
+			);
 	}
-	
-    @Override
-    public String toString() {
-        return SftpTransferSettings.class.getSimpleName()
-        + "[hostname=" + hostname + ":" + port + ", username=" + username + ", path=" + path + "]";
-    }
+
+	@Override
+	public String toString() {
+		return SftpTransferSettings.class.getSimpleName()
+		+ "[hostname=" + hostname + ":" + port + ", username=" + username + ", path=" + path + "]";
+	}
 }


### PR DESCRIPTION
Added public key authentication with support for password protected private keys (see syncany/syncany#134).

If a user doesn't provide a private key during the initialisation password-based authentication will be used. Password field is used to provide either the private key's password or a user's ssh password.

Altered setup:

```
Connection details for SFTP connection:
- Hostname: 10.211.55.6
- Privatekey Path (optional, default is none): /home/user/.ssh/id_rsa
- Username: user
- Password (not displayed): 
- Path: sy
- Port (optional, default is 22): 
```
