### PR TITLE
Update Jsch, activate more ex

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 	compile		"org.apache.sshd:sshd-core:0.9.0"
 	compile		"org.apache.commons:commons-vfs2:2.0"
 
-	pluginjar	"com.jcraft:jsch:0.1.50"
+	pluginjar	"com.jcraft:jsch:0.1.51"
 	pluginjar	"org.apache.sshd:sshd-core:0.9.0"
 	pluginjar	"org.apache.commons:commons-vfs2:2.0"
 

--- a/src/main/java/org/syncany/plugins/sftp/SftpTransferManager.java
+++ b/src/main/java/org/syncany/plugins/sftp/SftpTransferManager.java
@@ -83,6 +83,7 @@ import com.jcraft.jsch.UserInfo;
  */
 public class SftpTransferManager extends AbstractTransferManager {
 	private static final Logger logger = Logger.getLogger(SftpTransferManager.class.getSimpleName());
+	private static final String SUPPORTED_KEX = "diffie-hellman-group1-sha1,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1,diffie-hellman-group-exchange-sha256";
 
 	private JSch secureChannel;
 	private Session secureSession;
@@ -97,6 +98,11 @@ public class SftpTransferManager extends AbstractTransferManager {
 
 	public SftpTransferManager(SftpTransferSettings connection, Config config) {
 		super(connection, config);
+
+		// Activate more kex
+		// see http://sourceforge.net/p/jsch/patches/7/
+		// see https://github.com/syncany/syncany/issues/385
+		JSch.setConfig("kex", SUPPORTED_KEX);
 
 		this.secureChannel = new JSch();
 		this.repoPath = connection.getPath();


### PR DESCRIPTION
We're manually setting the kex protocols because it's unlikely that Jsch will include [the patch](http://sourceforge.net/p/jsch/patches/7/) in the near future (current release is one year old)

closes syncany/syncany#385