### PR TITLE
gradle: wrapper: update URL to HTTPS

### DIFF
--- a/core/gradle/wrapper/wrapper.properties
+++ b/core/gradle/wrapper/wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-bin.zip


### PR DESCRIPTION
HTTP link is no more: fails with 403 error.