### PR TITLE
Fix host key check exception introduced in PR #7

### DIFF
--- a/src/main/java/org/syncany/plugins/sftp/SftpTransferSettings.java
+++ b/src/main/java/org/syncany/plugins/sftp/SftpTransferSettings.java
@@ -62,9 +62,10 @@ public class SftpTransferSettings extends TransferSettings {
 	@Setup(order = 6, description = "Port")
 	private int port = 22;
 
+	public enum CheckHostKeyMode { ASK, YES, NO }
 	@Element(name = "checkHostKey", required = false)
-	@Setup(order = 7, description = "Whether to check the server key against known hosts (if not set, then prompt the user whether to add the key if it does not match)")
-	private Boolean checkHostKey = null;
+	@Setup(order = 7, description = "Whether to check the server key against known hosts")
+	private CheckHostKeyMode checkHostKey = CheckHostKeyMode.ASK;
 
 	public String getHostname() {
 		return hostname;
@@ -114,15 +115,16 @@ public class SftpTransferSettings extends TransferSettings {
 		this.privateKey = privateKey;
 	}
 
-	public Boolean getCheckHostKey() {
+	public CheckHostKeyMode getCheckHostKey() {
 		return checkHostKey;
 	}
 
 	public String getCheckHostKeyAsString() {
-		return checkHostKey == null ? "ask" : (checkHostKey ? "yes" : "no");
+		return checkHostKey == CheckHostKeyMode.ASK ? "ask" :
+			(checkHostKey == CheckHostKeyMode.YES ? "yes" : "no");
 	}
 
-	public void setCheckHostKey(Boolean checkHostKey) {
+	public void setCheckHostKey(CheckHostKeyMode checkHostKey) {
 		this.checkHostKey = checkHostKey;
 	}
 

--- a/src/main/java/org/syncany/plugins/sftp/SftpTransferSettings.java
+++ b/src/main/java/org/syncany/plugins/sftp/SftpTransferSettings.java
@@ -62,9 +62,8 @@ public class SftpTransferSettings extends TransferSettings {
 	@Setup(order = 6, description = "Port")
 	private int port = 22;
 
+	// No need to expose this as a field to the user (only tests would want NO)
 	public enum CheckHostKeyMode { ASK, YES, NO }
-	@Element(name = "checkHostKey", required = false)
-	@Setup(order = 7, description = "Whether to check the server key against known hosts")
 	private CheckHostKeyMode checkHostKey = CheckHostKeyMode.ASK;
 
 	public String getHostname() {

--- a/src/test/java/org/syncany/tests/plugin/sftp/SftpConnectionPluginTest.java
+++ b/src/test/java/org/syncany/tests/plugin/sftp/SftpConnectionPluginTest.java
@@ -43,6 +43,9 @@ import org.syncany.plugins.sftp.SftpTransferSettings;
 import org.syncany.plugins.transfer.StorageException;
 import org.syncany.plugins.transfer.TransferManager;
 import org.syncany.plugins.transfer.TransferPlugin;
+import org.syncany.plugins.transfer.TransferPluginOption;
+import org.syncany.plugins.transfer.TransferPluginOption.ValidationResult;
+import org.syncany.plugins.transfer.TransferPluginOptions;
 import org.syncany.plugins.transfer.files.RemoteFile;
 import org.syncany.plugins.transfer.files.MultichunkRemoteFile;
 import org.syncany.tests.util.TestFileUtil;
@@ -132,6 +135,37 @@ public class SftpConnectionPluginTest {
 		// This should cause a Storage exception, because the path does not exist
 		transferManager.connect();	
 		transferManager.init(true);
+	}
+
+	@Test
+	public void testTransferSettingsFields() throws StorageException {
+		// Checks the fields types and annotations to catch runtime errors
+
+		SftpTransferSettings settings = validSftpTransferSettings;
+
+		List<TransferPluginOption> pluginOptions =
+				TransferPluginOptions.getOrderedOptions(settings.getClass());
+
+		for (TransferPluginOption option : pluginOptions) {
+			String fieldName = option.getName();
+			String fieldValue = settings.getField(fieldName);
+			ValidationResult validationRes = option.isValid(fieldValue);
+			assertEquals("Value '" + fieldValue +  "' of field '" + fieldName +
+					"' must pass validity check",
+					ValidationResult.VALID, validationRes);
+		}
+	}
+
+	@Test(expected=StorageException.class)
+	public void testInvalidSettingsValidation() throws StorageException {
+		assertFalse(invalidSftpTransferSettings.isValid());
+		invalidSftpTransferSettings.validateRequiredFields();
+	}
+
+	@Test
+	public void testValidSettingsValidation() throws StorageException {
+		assertTrue(validSftpTransferSettings.isValid());
+		validSftpTransferSettings.validateRequiredFields();
 	}
 	
 	@Test(expected=StorageException.class)

--- a/src/test/java/org/syncany/tests/plugin/sftp/SftpConnectionPluginTest.java
+++ b/src/test/java/org/syncany/tests/plugin/sftp/SftpConnectionPluginTest.java
@@ -93,7 +93,7 @@ public class SftpConnectionPluginTest {
 		validSftpTransferSettings.setPassword("pass");
 		validSftpTransferSettings.setPort(EmbeddedSftpServerTest.PORT);
 		validSftpTransferSettings.setPath("/repo");		
-		validSftpTransferSettings.setCheckHostKey(false);
+		validSftpTransferSettings.setCheckHostKey(SftpTransferSettings.CheckHostKeyMode.NO);
 
 		invalidSftpTransferSettings = pluginInfo.createEmptySettings();
 	}
@@ -128,7 +128,7 @@ public class SftpConnectionPluginTest {
 		connection.setPassword("pass");
 		connection.setPort(EmbeddedSftpServerTest.PORT);
 		connection.setPath("/path/does/not/exist");
-		connection.setCheckHostKey(false);
+		validSftpTransferSettings.setCheckHostKey(SftpTransferSettings.CheckHostKeyMode.NO);
 		
 		TransferManager transferManager = pluginInfo.createTransferManager(connection, null);
 		

--- a/src/test/java/org/syncany/tests/plugin/sftp/SftpConnectionPluginTest.java
+++ b/src/test/java/org/syncany/tests/plugin/sftp/SftpConnectionPluginTest.java
@@ -107,7 +107,7 @@ public class SftpConnectionPluginTest {
 		Plugin pluginInfo = Plugins.get("sftp");
 		
 		assertNotNull("PluginInfo should not be null.", pluginInfo);
-		assertEquals("Plugin ID should be 'ssh'.", "sftp", pluginInfo.getId());
+		assertEquals("Plugin ID should be 'sftp'.", "sftp", pluginInfo.getId());
 		assertNotNull("Plugin version should not be null.", pluginInfo.getVersion());
 		assertNotNull("Plugin name should not be null.", pluginInfo.getName());
 	}

--- a/src/test/java/org/syncany/tests/plugin/sftp/SftpConnectionPluginTest.java
+++ b/src/test/java/org/syncany/tests/plugin/sftp/SftpConnectionPluginTest.java
@@ -51,7 +51,8 @@ public class SftpConnectionPluginTest {
 	private static File tempLocalSourceDir;
 	
 	private SftpTransferSettings validSftpTransferSettings;
-	
+	private SftpTransferSettings invalidSftpTransferSettings;
+
 	@BeforeClass
 	public static void beforeTestSetup() {
 		try {
@@ -90,6 +91,8 @@ public class SftpConnectionPluginTest {
 		validSftpTransferSettings.setPort(EmbeddedSftpServerTest.PORT);
 		validSftpTransferSettings.setPath("/repo");		
 		validSftpTransferSettings.setCheckHostKey(false);
+
+		invalidSftpTransferSettings = pluginInfo.createEmptySettings();
 	}
 	
 	@After
@@ -135,8 +138,8 @@ public class SftpConnectionPluginTest {
 	public void testConnectWithInvalidSettings() throws StorageException {
 		TransferPlugin pluginInfo = Plugins.get("sftp", TransferPlugin.class);
 		
-		SftpTransferSettings connection = pluginInfo.createEmptySettings();		
-		TransferManager transferManager = pluginInfo.createTransferManager(connection, null);
+		TransferManager transferManager =
+			pluginInfo.createTransferManager(invalidSftpTransferSettings, null);
 		
 		// This should cause a Storage exception, because the path does not exist
 		transferManager.connect();		


### PR DESCRIPTION
Fix exception I introduced in PR #7 and add a new test that would have caught it: can't have fields of type nullable Boolean. (I missed it because I modified my patch after having tested end-to-end and only re-ran the tests without testing end-to-end again.) Changed it to Enum, but ultimately decided to not even expose it as a field at all.

commit cd0c20c26d3f325be7edaed165a5f4b689c3720f
    TransferSettings: don't expose key check as field
    
    No need to create clutter for the user. The user should always have
    it set to ASK or YES. NO is only useful to tests. We do want this
    configurable though, because the tests do need to set it to NO.

commit 9a4f35c393d9ced0138306daeb7d25ac3c235619
    TransferSettings: use enum, not nullable Boolean
    
    Fields of type nullable Boolean are not supported by core/ (fails at
    runtime with java.lang.RuntimeException: Unknown type: class
    java.lang.Boolean).
    
    Also, enum makes the interactive prompt better.

commit e23c669a84e3ec6934d5b12ed336332101dcc619
    test: add a check for TransferSettings fields
    
    Catches bug introduced in 483a11a40122d4bd7eb03ff548c737a322109c52
    (SftpTransferManager: expose host key check choice): nullable Boolean is
    not supported as a field type by core/ (fails at runtime with
    java.lang.RuntimeException: Unknown type: class java.lang.Boolean).

commit b9a5b95245dd8cec9e984812d3d414fbbe3203a9
    test: factor invalid settings into the fixture
    
    For re-use.

commit c3112c14967a5b34bdddc4435d5619e651c15fc7

    test: fix assert message about plugin id to match