### PR TITLE
deps: update com.jcraft:jsch to 0.1.55

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,11 +22,11 @@ project.ext {
 
 dependencies {
 	compile		project(':syncany-lib')
-	compile		"com.jcraft:jsch:0.1.52"
+	compile		"com.jcraft:jsch:0.1.55"
 	compile		"org.apache.sshd:sshd-core:0.14.0"
 	compile		"org.apache.commons:commons-vfs2:2.0"
 
-	pluginjar	"com.jcraft:jsch:0.1.52"
+	pluginjar	"com.jcraft:jsch:0.1.55"
 	pluginjar	"org.apache.sshd:sshd-core:0.9.0"
 	pluginjar	"org.apache.commons:commons-vfs2:2.0"
 


### PR DESCRIPTION
Fixes connection to OpenSSH 8.2 server that fails on 0.1.52 with:

    com.jcraft.jsch.JSchException: Session.connect: java.io.IOException: End of IO Stream Read

for both key and password auth (despite working for a OpenSSH 7.9 server). I can't spot any other relevant difference in supported algorithms etc in verbose SSH log other than the version.